### PR TITLE
Configure code analysis

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -116,11 +116,11 @@ csharp_space_between_method_call_empty_parameter_list_parentheses = false
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 ###############################
-# VB Coding Conventions       #
+# Code Analysis Severity      #
 ###############################
-[*.vb]
-# Modifier preferences
-visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion
 
 # CA1056: Internal classes should be instantiated
 dotnet_diagnostic.CA1812.severity = none
+
+# CA2007: Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2007.severity = none

--- a/NHSD.BuyingCatalogue.Documents.sln
+++ b/NHSD.BuyingCatalogue.Documents.sln
@@ -10,6 +10,14 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHSD.BuyingCatalogue.Documents.API.UnitTests", "test\NHSD.BuyingCatalogue.Documents.API.Tests\NHSD.BuyingCatalogue.Documents.API.UnitTests.csproj", "{60036623-6B49-4E45-AC3D-DEEBB09D0B74}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C37EF23A-0BA3-4C1C-93A0-CF35738F21CE}"
+	ProjectSection(SolutionItems) = preProject
+		test\.editorconfig = test\.editorconfig
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2E66BA6E-566A-4B4D-8C82-415148612C2E}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,2 +1,4 @@
-# CA1056: Internal classes should be instantiated
-dotnet_diagnostic.CA1812.severity = none
+[*.cs]
+
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = none


### PR DESCRIPTION
Added .editorconfig files for production and test projects so that warning severity may be configured and inappropriate rules disabled.