### PR TITLE
Add retry config

### DIFF
--- a/src/NHSD.BuyingCatalogue.Documents.API/Config/AzureBlobStorageHealthCheckSettings.cs
+++ b/src/NHSD.BuyingCatalogue.Documents.API/Config/AzureBlobStorageHealthCheckSettings.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace NHSD.BuyingCatalogue.Documents.API.Config
+{
+    internal sealed class AzureBlobStorageHealthCheckSettings
+    {
+        public TimeSpan Timeout { get; set; }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Documents.API/Config/AzureBlobStorageRetrySettings.cs
+++ b/src/NHSD.BuyingCatalogue.Documents.API/Config/AzureBlobStorageRetrySettings.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Text.Json.Serialization;
+using Azure.Core;
+
+namespace NHSD.BuyingCatalogue.Documents.API.Config
+{
+    internal sealed class AzureBlobStorageRetrySettings
+    {
+        public TimeSpan Delay { get; set; }
+
+        public TimeSpan MaxDelay { get; set; }
+
+        public int MaxRetries { get; set; }
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public RetryMode Mode { get; set; }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Documents.API/Config/AzureBlobStorageSettings.cs
+++ b/src/NHSD.BuyingCatalogue.Documents.API/Config/AzureBlobStorageSettings.cs
@@ -13,6 +13,10 @@ namespace NHSD.BuyingCatalogue.Documents.API.Config
 
         public string? ContainerName { get; set; }
 
+        public AzureBlobStorageHealthCheckSettings? HealthCheck { get; set; }
+
+        public AzureBlobStorageRetrySettings? Retry { get; set; }
+
         // Not part of the interface definition as its current use
         // is for logging only
         public Uri? Uri
@@ -33,9 +37,31 @@ namespace NHSD.BuyingCatalogue.Documents.API.Config
             }
         }
 
-        public override string ToString() =>
-            JsonSerializer.Serialize(
-                this,
-                new JsonSerializerOptions { WriteIndented = true });
+        public override string ToString()
+        {
+            var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+            jsonOptions.Converters.Add(new TimeSpanConverter());
+
+            return JsonSerializer.Serialize(this, jsonOptions);
+        }
+
+        private class TimeSpanConverter : JsonConverter<TimeSpan>
+        {
+            public override TimeSpan Read(
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(
+                Utf8JsonWriter writer,
+                TimeSpan value,
+                JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value.ToString());
+            }
+        }
     }
 }

--- a/src/NHSD.BuyingCatalogue.Documents.API/Config/IAzureBlobStorageSettings.cs
+++ b/src/NHSD.BuyingCatalogue.Documents.API/Config/IAzureBlobStorageSettings.cs
@@ -5,5 +5,9 @@
         string? ConnectionString { get; }
 
         string? ContainerName { get; }
+
+        AzureBlobStorageHealthCheckSettings? HealthCheck { get; }
+
+        AzureBlobStorageRetrySettings? Retry { get; }
     }
 }

--- a/src/NHSD.BuyingCatalogue.Documents.API/HealthChecks/ServiceCollectionHealthCheckExtensions.cs
+++ b/src/NHSD.BuyingCatalogue.Documents.API/HealthChecks/ServiceCollectionHealthCheckExtensions.cs
@@ -6,11 +6,18 @@ namespace NHSD.BuyingCatalogue.Documents.API.HealthChecks
 {
     internal static class ServiceCollectionHealthCheckExtensions
     {
-        public static IServiceCollection AddCustomHealthChecks(this IServiceCollection services, IAzureBlobStorageSettings storageSettings)
+        internal static IServiceCollection AddCustomHealthChecks(this IServiceCollection services, IAzureBlobStorageSettings storageSettings)
         {
             services.AddHealthChecks()
-                .AddAzureBlobStorage(storageSettings.ConnectionString, storageSettings.ContainerName, "Azure Blob Storage", HealthStatus.Degraded, new[] {HealthCheckTags.Ready})
-                .AddCheck("self", () => HealthCheckResult.Healthy(), new[] {HealthCheckTags.Live});
+                .AddAzureBlobStorage(
+                    storageSettings.ConnectionString,
+                    storageSettings.ContainerName,
+                    "Azure Blob Storage",
+                    HealthStatus.Degraded,
+                    new[] { HealthCheckTags.Ready },
+                    storageSettings.HealthCheck?.Timeout)
+                .AddCheck("self", () => HealthCheckResult.Healthy(), new[] { HealthCheckTags.Live });
+
             return services;
         }
     }

--- a/src/NHSD.BuyingCatalogue.Documents.API/Repositories/AzureBlobContainerClientFactory.cs
+++ b/src/NHSD.BuyingCatalogue.Documents.API/Repositories/AzureBlobContainerClientFactory.cs
@@ -1,0 +1,29 @@
+﻿using Azure.Storage.Blobs;
+using NHSD.BuyingCatalogue.Documents.API.Config;
+
+namespace NHSD.BuyingCatalogue.Documents.API.Repositories
+{
+    internal static class AzureBlobContainerClientFactory
+    {
+        internal static BlobContainerClient Create(IAzureBlobStorageSettings settings)
+        {
+            var retrySettings = settings.Retry;
+
+            var options = retrySettings == null
+                ? new BlobClientOptions()
+                : new BlobClientOptions
+                {
+                    Retry =
+                    {
+                        Mode = retrySettings.Mode,
+                        MaxRetries = retrySettings.MaxRetries,
+                        Delay = retrySettings.Delay,
+                        MaxDelay = retrySettings.MaxDelay
+                    },
+                };
+
+            return new BlobServiceClient(settings.ConnectionString, options)
+                .GetBlobContainerClient(settings.ContainerName);
+        }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Documents.API/Startup.cs
+++ b/src/NHSD.BuyingCatalogue.Documents.API/Startup.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
@@ -34,8 +33,7 @@ namespace NHSD.BuyingCatalogue.Documents.API
             var settings = Configuration.GetSection("AzureBlobStorage").Get<AzureBlobStorageSettings>();
             services.AddSingleton<IAzureBlobStorageSettings>(settings);
 
-            services.AddTransient(x => new BlobServiceClient(settings.ConnectionString)
-                .GetBlobContainerClient(settings.ContainerName));
+            services.AddTransient(x => AzureBlobContainerClientFactory.Create(settings));
 
             services.AddCustomHealthChecks(settings);
 

--- a/src/NHSD.BuyingCatalogue.Documents.API/appsettings.json
+++ b/src/NHSD.BuyingCatalogue.Documents.API/appsettings.json
@@ -1,6 +1,17 @@
 {
   "AzureBlobStorage": {
     "ConnectionString": "UseDevelopmentStorage=true",
-    "ContainerName": "container-1"
+    "ContainerName": "container-1",
+    "HealthCheck": {
+      "Timeout": "00:00:01"
+    },
+    "Retry": {
+      "Delay": "00:00:00.5",
+      "MaxDelay": "00:00:05",
+      "MaxRetries": "1",
+
+      // Exponential or Fixed
+      "Mode": "Exponential"
+    }
   }
 }

--- a/test/NHSD.BuyingCatalogue.Documents.API.Tests/AzureBlobContainerClientFactoryTests.cs
+++ b/test/NHSD.BuyingCatalogue.Documents.API.Tests/AzureBlobContainerClientFactoryTests.cs
@@ -1,0 +1,60 @@
+﻿using FluentAssertions;
+using NHSD.BuyingCatalogue.Documents.API.Config;
+using NHSD.BuyingCatalogue.Documents.API.Repositories;
+using NUnit.Framework;
+
+namespace NHSD.BuyingCatalogue.Documents.API.UnitTests
+{
+    [TestFixture]
+    internal sealed class AzureBlobContainerClientFactoryTests
+    {
+        [Test]
+        public void Create_NullRetryOptions_ReturnsContainerClient()
+        {
+            const string accountName = "devstoreaccount1";
+            const string containerName = "Container";
+            const string uri = "http://127.0.0.1:10000/" + accountName;
+            const string connectionString =
+                "DefaultEndpointsProtocol=http;AccountName="
+                + accountName + "UnitTest;AccountKey=;BlobEndpoint="
+                + uri;
+
+            var settings = new AzureBlobStorageSettings
+            {
+                ConnectionString = connectionString,
+                ContainerName = containerName,
+            };
+
+            var client = AzureBlobContainerClientFactory.Create(settings);
+
+            client.Should().NotBeNull();
+            client.AccountName.Should().Be(accountName);
+            client.Name.Should().Be(containerName);
+        }
+
+        [Test]
+        public void Create_WithRetryOptions_ReturnsContainerClient()
+        {
+            const string accountName = "devstoreaccount1";
+            const string containerName = "Container";
+            const string uri = "http://127.0.0.1:10000/" + accountName;
+            const string connectionString =
+                "DefaultEndpointsProtocol=http;AccountName="
+                + accountName + "UnitTest;AccountKey=;BlobEndpoint="
+                + uri;
+
+            var settings = new AzureBlobStorageSettings
+            {
+                ConnectionString = connectionString,
+                ContainerName = containerName,
+                Retry = new AzureBlobStorageRetrySettings(),
+            };
+
+            var client = AzureBlobContainerClientFactory.Create(settings);
+
+            client.Should().NotBeNull();
+            client.AccountName.Should().Be(accountName);
+            client.Name.Should().Be(containerName);
+        }
+    }
+}


### PR DESCRIPTION
Adds configuration for the retry policy to reduce the length of timeout when communication with the storage service fails.

[AB#5014](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/5014)